### PR TITLE
Delete announcement entry for RedOctane Games

### DIFF
--- a/index.json
+++ b/index.json
@@ -36,17 +36,6 @@
             "category": "yarg"
         },
         {
-            "md": "0031_rog",
-            "type": "announcement",
-            "title": "RedOctane Games and The Future of YARG",
-            "thumb": "rog.webp",
-            "authors": [
-                "EliteAsian123"
-            ],
-            "release": "2025-08-07T02:55:34.274Z",
-            "category": "yarg"
-        },
-        {
             "md": "0030_setlist-wave9",
             "type": "announcement",
             "title": "YARG Setlist: Wave 9 Trailer",


### PR DESCRIPTION
Removed announcement for 'RedOctane Games and The Future of YARG'.